### PR TITLE
Correct typo: kanja -> kanji

### DIFF
--- a/furigana/furigana.py
+++ b/furigana/furigana.py
@@ -114,7 +114,7 @@ def to_plaintext(text):
     for pair in split_furigana(text):
         if len(pair)==2:
             kanji,hira = pair
-            text2 += "%s(%s)" % (kanja,hira)
+            text2 += "%s(%s)" % (kanji,hira)
         else:
             text2 += pair[0]
     return text2


### PR DESCRIPTION
The `to_plaintext()` function is broken because it tries to retrieve a variable called `kanja` instead of `kanji`. This PR fixes this.